### PR TITLE
Fix `auto_get_packages` function and add log messages

### DIFF
--- a/lua/mason-null-ls/automatic_installation.lua
+++ b/lua/mason-null-ls/automatic_installation.lua
@@ -76,9 +76,17 @@ return function()
 			-- -@param pkg Package
 			function(pkg)
 				if not pkg:is_installed() then
+                    vim.notify(("[mason-null-ls] automatically installing %s"):format(pkg.name))
 					pkg:install({
 						version = version,
-					})
+                    }):once(
+                        'closed',
+                        vim.schedule_wrap(function()
+                            if pkg:is_installed() then
+                                vim.notify(("[mason-null-ls] %s was automatically installed"):format(pkg.name))
+                            end
+                        end)
+                    )
 				end
 			end
 		)

--- a/lua/mason-null-ls/automatic_installation.lua
+++ b/lua/mason-null-ls/automatic_installation.lua
@@ -15,11 +15,11 @@ end
 
 local function auto_get_packages()
 	local sources = {}
-	sources = vim.tbl_deep_extend('force', sources, vim.tbl_keys(require('null-ls.builtins').diagnostics))
-	sources = vim.tbl_deep_extend('force', sources, vim.tbl_keys(require('null-ls.builtins').formatting))
-	sources = vim.tbl_deep_extend('force', sources, vim.tbl_keys(require('null-ls.builtins').code_actions))
-	sources = vim.tbl_deep_extend('force', sources, vim.tbl_keys(require('null-ls.builtins').completion))
-	sources = vim.tbl_deep_extend('force', sources, vim.tbl_keys(require('null-ls.builtins').hover))
+	sources = vim.list_extend(sources, vim.tbl_keys(require('null-ls.builtins').diagnostics))
+	sources = vim.list_extend(sources, vim.tbl_keys(require('null-ls.builtins').formatting))
+	sources = vim.list_extend(sources, vim.tbl_keys(require('null-ls.builtins').code_actions))
+	sources = vim.list_extend(sources, vim.tbl_keys(require('null-ls.builtins').completion))
+	sources = vim.list_extend(sources, vim.tbl_keys(require('null-ls.builtins').hover))
 	local tools = removeArrayDuplicates(sources)
 	return tools
 end


### PR DESCRIPTION
1. I encountered some problems using the [`tbl_deep_extend`](https://neovim.io/doc/user/lua.html#vim.tbl_deep_extend()) function to concatenate lists, but those problems were fixed by switching to [`list_extend`](https://neovim.io/doc/user/lua.html#vim.list_extend()).
2. I added two log messages during automatic installation notifying the user that a source is being installed.