### PR TITLE
feat(source): add python pylama source

### DIFF
--- a/lua/mason-null-ls/mappings/filetype.lua
+++ b/lua/mason-null-ls/mappings/filetype.lua
@@ -383,7 +383,7 @@ return {
     "mypy",
     --   "pycodestyle",
     --   "pydocstyle",
-    --   "pylama",
+    "pylama",
     "pylint",
     --   "pyproject_flake8",
     --   "semgrep",

--- a/lua/mason-null-ls/mappings/source.lua
+++ b/lua/mason-null-ls/mappings/source.lua
@@ -51,6 +51,7 @@ M.null_ls_to_package = {
 	['prettierd'] = 'prettierd',
 	['proselint'] = 'proselint',
 	['psalm'] = 'psalm',
+	['pylama'] = 'pylama',
 	['pylint'] = 'pylint',
 	['revive'] = 'revive',
 	['rome'] = 'rome',


### PR DESCRIPTION
Add pylama source which is now available in the mason package registry.

Package list: https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#pylama
PR: https://github.com/williamboman/mason.nvim/pull/523