### PR TITLE
Add source for PHP CS fixer

### DIFF
--- a/lua/mason-null-ls/mappings/filetype.lua
+++ b/lua/mason-null-ls/mappings/filetype.lua
@@ -355,7 +355,7 @@ return {
     --   "phpstan",
     "psalm",
     --   "phpcbf",
-    --   "phpcsfixer",
+      "phpcsfixer",
     --   "pint",
   },
   -- prisma = {

--- a/lua/mason-null-ls/mappings/source.lua
+++ b/lua/mason-null-ls/mappings/source.lua
@@ -47,6 +47,7 @@ M.null_ls_to_package = {
 	['misspell'] = 'misspell',
 	['mypy'] = 'mypy',
 	['phpcbf'] = 'phpcbf',
+	['phpcsfixer'] = 'php-cs-fixer',
 	['prettier'] = 'prettier',
 	['prettierd'] = 'prettierd',
 	['proselint'] = 'proselint',


### PR DESCRIPTION
This PR adds the PHP CS fixer source found in null-ls.

https://github.com/williamboman/mason.nvim/blob/main/lua/mason-registry/php-cs-fixer/init.lua

https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/phpcsfixer.lua