### PR TITLE
feat(jsonlint): support for `jsonlint` is enabled

### DIFF
--- a/lua/mason-null-ls/mappings/filetype.lua
+++ b/lua/mason-null-ls/mappings/filetype.lua
@@ -254,7 +254,7 @@ return {
         },
         json = {
                 "cfn-lint",
-                --   "jsonlint",
+                "jsonlint",
                 --   "spectral",
                 --   "deno_fmt",
                 --   "dprint",

--- a/lua/mason-null-ls/mappings/source.lua
+++ b/lua/mason-null-ls/mappings/source.lua
@@ -42,6 +42,7 @@ M.null_ls_to_package = {
 	['isort'] = 'isort',
 	['joker'] = 'joker',
 	['jq'] = 'jq',
+	['jsonlint'] = 'jsonlint',
 	['ktlint'] = 'ktlint',
 	['luacheck'] = 'luacheck',
 	['markdownlint'] = 'markdownlint',


### PR DESCRIPTION
Hi! @jayp0521 - I have enabled support for [JSONLint](https://github.com/zaach/jsonlint), it works fine with [Mason](https://github.com/williamboman/mason.nvim) in its latest versions. Could you add it? Thanks :)